### PR TITLE
Fix filter_lines to use altroot parameter

### DIFF
--- a/resources/scponly_user.rb
+++ b/resources/scponly_user.rb
@@ -69,8 +69,8 @@ action :create do
       creates "#{altroot}/etc/passwd"
     end
 
-    filter_lines "#{altroot}/etc/passwd/" do
-      filters(substitute: [%r{/home/chroot}, %r{/home/chroot}, ''])
+    filter_lines "#{altroot}/etc/passwd" do
+      filters(substitute: [/#{altroot}/, %r{#{altroot}/}, ''])
       sensitive false
     end
 

--- a/spec/scponly-test/scponly_chroot_spec.rb
+++ b/spec/scponly-test/scponly_chroot_spec.rb
@@ -68,6 +68,15 @@ describe 'scponly-test::scponly_chroot' do
           creates: "#{altroot}/etc/passwd"
         )
       end
+      it do
+        expect(chef_run).to edit_filter_lines('/var/lib/chroots/etc/passwd')
+          .with(
+            filters: {
+              substitute: [%r{/var/lib/chroots}, %r{/var/lib/chroots/}, ''],
+            },
+            sensitive: false
+          )
+      end
     end
   end
 end

--- a/test/integration/scponly-chroot/inspec/scponly_chroot.rb
+++ b/test/integration/scponly-chroot/inspec/scponly_chroot.rb
@@ -15,6 +15,10 @@ describe user('scponly_test_chroot') do
   its('group') { should cmp 'scponly_test_chroot' }
 end
 
+describe file '/var/lib/chroots/etc/passwd' do
+  its('content') { should match %r{^scponly_test_chroot:x:1001:1001::/home/scponly_test_chroot:/usr/sbin/scponlyc$} }
+end
+
 %w(bin etc lib64 usr).each do |d|
   describe directory("#{altroot}/#{d}") do
     it { should exist }


### PR DESCRIPTION
Two problems this fixes:
- Use /etc/passwd instead of /etc/passwd/
- Update the regex to use the altroot parameter instead of hard coding
  /home/chroot