### PR TITLE
Add support for AlmaLinux 9

### DIFF
--- a/kitchen.dokken.yml
+++ b/kitchen.dokken.yml
@@ -21,3 +21,9 @@ platforms:
     driver:
       image: dokken/almalinux-8
       pid_one_command: /usr/lib/systemd/systemd
+  - name: almalinux-9
+    driver:
+      image: dokken/almalinux-9
+      pid_one_command: /usr/lib/systemd/systemd
+    driver_config:
+      flavor_ref: m1.medium

--- a/kitchen.dokken.yml
+++ b/kitchen.dokken.yml
@@ -3,7 +3,7 @@ driver:
   name: dokken
   privileged: true  # because Docker and SystemD/Upstart
   chef_image: cincproject/cinc
-  chef_version: <%= ENV['CHEF_VERSION'] || '17' %>
+  chef_version: <%= ENV['CHEF_VERSION'] || '18' %>
   pull_chef_image: false
   pull_platform_image: false
 
@@ -25,5 +25,3 @@ platforms:
     driver:
       image: dokken/almalinux-9
       pid_one_command: /usr/lib/systemd/systemd
-    driver_config:
-      flavor_ref: m1.medium

--- a/kitchen.openstack.yml
+++ b/kitchen.openstack.yml
@@ -25,3 +25,10 @@ platforms:
       image_ref: "AlmaLinux 8"
     transport:
       username: almalinux
+  - name: almalinux-9
+    driver_plugin: openstack
+    driver_config:
+      image_ref: "AlmaLinux 9"
+      flavor_ref: "m1.medium"
+    transport:
+      username: almalinux

--- a/kitchen.openstack.yml
+++ b/kitchen.openstack.yml
@@ -25,6 +25,7 @@ platforms:
       image_ref: "AlmaLinux 8"
     transport:
       username: almalinux
+
   - name: almalinux-9
     driver_plugin: openstack
     driver_config:

--- a/kitchen.yml
+++ b/kitchen.yml
@@ -12,7 +12,7 @@ transport:
 provisioner:
   name: chef_infra
   product_name: cinc
-  product_version: '17'
+  product_version: '18'
   enforce_idempotency: true
   multiple_converge: 2
   deprecations_as_errors: true

--- a/kitchen.yml
+++ b/kitchen.yml
@@ -1,6 +1,7 @@
 ---
 driver:
   name: vagrant
+  flavor_ref: m1.medium
 
 verifier:
   name: inspec
@@ -18,6 +19,7 @@ provisioner:
 
 platforms:
   - name: almalinux-8
+  - name: almalinux-9
 
 suites:
   - name: default

--- a/metadata.rb
+++ b/metadata.rb
@@ -9,7 +9,9 @@ description      'Installs/Configures osl-scponly'
 version          '1.6.0'
 
 supports         'almalinux', '~> 8.0'
+supports         'almalinux', '~> 9.0'
 
 depends          'line'
 depends          'osl-repos'
 depends          'osl-selinux'
+depends          'yum-osuosl'

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -17,6 +17,7 @@
 # limitations under the License.
 
 include_recipe 'osl-repos::epel'
+include_recipe 'yum-osuosl'
 
 package 'scponly'
 

--- a/resources/scponly_user.rb
+++ b/resources/scponly_user.rb
@@ -24,6 +24,7 @@ property :binaries,
             /bin/rm
             /bin/rmdir
             /bin/scp
+            /usr/libexec/openssh/sftp-server
             /usr/sbin/scponlyc
           )
 

--- a/spec/scponly-test/scponly_chroot_spec.rb
+++ b/spec/scponly-test/scponly_chroot_spec.rb
@@ -46,6 +46,7 @@ describe 'scponly-test::scponly_chroot' do
         /bin/rm
         /bin/rmdir
         /bin/scp
+        /usr/libexec/openssh/sftp-server
         /usr/sbin/scponlyc
       )
       it do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -5,9 +5,14 @@ ALMA_8 = {
   platform: 'almalinux',
   version: '8',
 }.freeze
+ALMA_9 = {
+  platform: 'almalinux',
+  version: '9',
+}.freeze
 
 ALL_PLATFORMS = [
   ALMA_8,
+  ALMA_9,
 ].freeze
 
 RSpec.configure do |config|


### PR DESCRIPTION
Haven't been able to test dokken because of berkshelf. RHEL 9 needs the sftp-server binary to the chroot jail. Doesn't break the other platforms, so I didn't add logic.